### PR TITLE
fix: add STS retry backoff for external Iceberg table creation (ZD #121078)

### DIFF
--- a/bigquery/external-iceberg-tables/bq_external_iceberg_tables_create_refresh.py
+++ b/bigquery/external-iceberg-tables/bq_external_iceberg_tables_create_refresh.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import time
+import random
 import logging
 from typing import List, Tuple
 
@@ -167,34 +169,46 @@ def main():
             tables = reader.list_tables(namespace)
 
             for identifier in tables:
-                try:
-                    table = reader.catalog.load_table(identifier)
-                    metadata_path = get_metadata_path(table)
-                    original_table_name = identifier[-1]
-                    # Apply BigQuery-safe transformation (handle reserved keyword "table")
-                    table_name = bq_safe_table_name(original_table_name)
+                for attempt in range(5):
+                    try:
+                        table = reader.catalog.load_table(identifier)
+                        metadata_path = get_metadata_path(table)
+                        original_table_name = identifier[-1]
 
-                    create_external_iceberg_table(
-                        bq_client,
-                        dataset_id,
-                        table_name,
-                        metadata_path
-                    )
+                        # Apply BigQuery-safe transformation (handle reserved keyword "table")
+                        table_name = bq_safe_table_name(original_table_name)
 
-                    if original_table_name != table_name:
-                        logger.info(
-                            f"✅ Created {dataset_id}.{table_name} (renamed from {original_table_name} to avoid reserved keyword)"
-                        )
-                    else:
-                        logger.info(
-                            f"✅ Created {dataset_id}.{table_name}"
+                        create_external_iceberg_table(
+                            bq_client,
+                            dataset_id,
+                            table_name,
+                            metadata_path
                         )
 
-                except Exception as table_err:
-                    logger.error(
-                        f"❌ Failed table {identifier}: {table_err}"
-                    )
-                    continue
+                        if original_table_name != table_name:
+                            logger.info(
+                                f"✅ Created {dataset_id}.{table_name} (renamed from {original_table_name} to avoid reserved keyword)"
+                            )
+                        else:
+                            logger.info(
+                                f"✅ Created {dataset_id}.{table_name}"
+                            )
+
+                        break  # success — exit retry loop
+
+                    except Exception as table_err:
+                        if "quota_exceeded" in str(table_err) and attempt < 4:
+                            wait = (2 ** attempt) + random.uniform(0, 1)
+                            logger.warning(
+                                f"⏳ STS throttled on {identifier}, retrying in {wait:.1f}s "
+                                f"(attempt {attempt + 1}/5)"
+                            )
+                            time.sleep(wait)
+                        else:
+                            logger.error(
+                                f"❌ Failed table {identifier}: {table_err}"
+                            )
+                            break
 
         except Exception as ns_err:
             logger.error(


### PR DESCRIPTION
## Summary

Adds exponential backoff retry logic to `bq_external_iceberg_tables_create_refresh.py`
to handle Google Security Token Service (STS) rate limiting errors when creating
external BigQuery datasets backed by Iceberg tables.

Resolves: **Zendesk #121078**

## Problem

When syncing catalogs with a large number of tables, the Google STS service throttles
token exchange requests:

```
quota_exceeded – [Security Token Service] The request was throttled due to rate limits
on the following metric: "Token exchange requests". Please retry after a few seconds.
```

Each table triggers two STS calls in quick succession (`load_table` + BQ connection auth).
With no retry logic, affected tables are permanently skipped, resulting in an incomplete sync.

## Change

Minimal — 2 stdlib imports (`time`, `random`) and a retry loop wrapping the existing
inner `try/except`. Max 5 attempts with exponential backoff + jitter on `quota_exceeded`
errors only. Non-STS errors surface immediately — no change to existing error handling.

No new dependencies, functions, classes or config required.

## Files Changed

- `bigquery/external-iceberg-tables/bq_external_iceberg_tables_create_refresh.py`

## Testing

- [x] Tables previously failing with `quota_exceeded` now retry and succeed
- [x] Warning log `⏳ STS throttled on <identifier>, retrying in Xs (attempt N/5)` emitted on throttle
- [ ] Non-STS errors still surface immediately without retrying
- [x] Clean runs complete with no behaviour change