### PR TITLE
feat: add lineage and metadata export skills for all lakehouse use cases

### DIFF
--- a/skills/atlan-lakehouse/SKILL.md
+++ b/skills/atlan-lakehouse/SKILL.md
@@ -5,15 +5,16 @@ description: >
   build reports on assets/glossaries/tags/user adoption, or analyze metadata from the lakehouse.
   Works across platforms: Snowflake (Cortex Code), Databricks (Genie Code), and Python (PyIceberg).
   Includes the GOLD namespace (curated, pre-joined star-schema tables for simplified asset metadata queries),
-  plus SQL template library for metadata completeness, glossary export,
+  plus SQL template library for metadata completeness, metadata export, glossary export,
+  lineage analysis (impact analysis, root cause analysis, coverage, hub identification, dashboard impact, tag propagation),
   and comprehensive usage analytics (active users, feature adoption, engagement, retention, health scoring).
 license: Apache-2.0
 compatibility: SQL (Snowflake, Databricks), Python 3.9+ with PyIceberg
 metadata:
   author: atlan-platform-team
-  version: "1.0.0"
+  version: "1.1.0"
   category: data-integration
-  keywords: atlan-lakehouse, iceberg, polaris, pyiceberg, analytics, usage-analytics, snowflake, cortex, databricks, genie, lineage, glossary, metadata-completeness, gold-namespace
+  keywords: atlan-lakehouse, iceberg, polaris, pyiceberg, analytics, usage-analytics, snowflake, cortex, databricks, genie, lineage, lineage-impact, lineage-root-cause, lineage-export, lineage-tags, lineage-hubs, downstream-dashboards, metadata-export, metadata-completeness, glossary, gold-namespace, data-governance
 ---
 
 # Atlan Lakehouse Skill
@@ -79,8 +80,19 @@ Activate this skill when:
 - User wants simplified asset metadata queries using pre-joined tables (GOLD namespace)
 - User needs cross-type asset reports spanning relational, BI, pipeline, DQ, glossary, or data mesh assets
 - User needs to assess metadata completeness, tag/description/owner coverage
+- User needs to export asset metadata for AI applications, data marketplaces, or reverse sync workflows
 - User needs to export and analyze glossary terms with categories and assigned entities
 - User wants to track historical metadata changes or generate audit trails
+- **Lineage use cases** — any of:
+  - Find orphaned/unused assets with no lineage (cleanup candidates)
+  - Detect circular dependencies in the data pipeline
+  - Calculate lineage coverage percentages (overall or by connector)
+  - Identify the most connected "hub" assets with the highest blast radius
+  - Export the full lineage graph for impact analysis or post-deployment validation
+  - Perform impact analysis before modifying a table — find all downstream dependencies
+  - Perform root cause analysis — trace data quality issues back upstream
+  - Find all BI dashboards (Tableau, Power BI, Looker, etc.) downstream of a source table
+  - Measure tag/governance label propagation across lineage hops
 - User wants to analyze product adoption: DAU/WAU/MAU, feature engagement, retention, or engagement depth
 - User wants to build usage dashboards or customer health scorecards
 - User wants to identify churned/reactivated users, power users, or engagement tiers
@@ -111,7 +123,7 @@ After determining your platform, choose the right namespace for the query. Follo
 1. **Asset metadata** (completeness, ownership, descriptions, certification, asset inventory, glossary, DQ checks, pipelines, BI assets, data mesh)?
    → **Start with the `GOLD` namespace.** Use `GOLD.ASSETS` as the hub table, join to detail tables as needed.
 
-2. **Asset metadata + tags, custom metadata, readmes, or lineage?**
+2. **Asset metadata + tags, custom metadata, readmes, lineage, or metadata export?**
    → **Hybrid approach:** Start from `GOLD.ASSETS` for core asset data, then join to `ENTITY_METADATA` tables for what GOLD doesn't have:
    - `ENTITY_METADATA.TAGS` — classification tags on assets
    - `ENTITY_METADATA.CUSTOM_METADATA` — custom metadata attributes
@@ -119,13 +131,16 @@ After determining your platform, choose the right namespace for the query. Follo
    - `ENTITY_METADATA.PROCESS` / `COLUMN_PROCESS` / `BI_PROCESS` — lineage relationships
    - Use `ENTITY_METADATA` directly if GOLD adds no value for the specific query.
 
-3. **Usage analytics** (DAU/WAU/MAU, feature adoption, engagement, retention, health scoring)?
+3. **Lineage analysis** (impact, root cause, coverage, hub assets, tag propagation, downstream dashboards)?
+   → **Hybrid approach:** Use `GOLD.ASSETS` joined to the customer-managed `LINEAGE` table (created separately — see [Set up lineage tables](https://docs.atlan.com/platform/lakehouse/references/set-up-lineage-tables)). The `LINEAGE` table columns are: `start_guid`, `start_name`, `start_type`, `related_guid`, `related_name`, `related_type`, `direction` (`UPSTREAM`/`DOWNSTREAM`), `level` (hop depth).
+
+4. **Usage analytics** (DAU/WAU/MAU, feature adoption, engagement, retention, health scoring)?
    → **`USAGE_ANALYTICS` namespace** (`PAGES`, `TRACKS`, `USERS`).
 
-4. **Job/pipeline health** (DQ scores, job success rates, pipeline duration)?
+5. **Job/pipeline health** (DQ scores, job success rates, pipeline duration)?
    → **`OBSERVABILITY` namespace** (`JOB_METRICS`).
 
-5. **Historical/temporal changes** (audit trails, point-in-time snapshots)?
+6. **Historical/temporal changes** (audit trails, point-in-time snapshots)?
    → **`ENTITY_HISTORY` namespace** (mirrors `ENTITY_METADATA` with `snapshot_timestamp` / `snapshot_date`).
 
 ## Connecting to the Atlan Lakehouse
@@ -316,7 +331,9 @@ Detailed schemas, conventions, and SQL templates are organized in the `reference
 | Reference | Description |
 |-----------|-------------|
 | [GOLD Namespace Schema](references/gold-namespace-schema.md) | Complete column-level schema for all GOLD tables (ASSETS, RELATIONAL_ASSET_DETAILS, GLOSSARY_DETAILS, DATA_QUALITY_DETAILS, PIPELINE_DETAILS, BI_ASSET_DETAILS, DATA_MESH_DETAILS) plus best practices |
-| [GOLD Namespace Templates](references/gold-namespace-templates.md) | SQL templates for asset inventory, metadata completeness, glossary export using GOLD tables |
+| [GOLD Namespace Templates](references/gold-namespace-templates.md) | SQL templates for asset inventory, metadata completeness, and glossary export using GOLD tables |
+| [Lineage Templates](references/lineage-templates.md) | SQL templates for all lineage use cases: assets without lineage, circular dependencies, coverage summary, lineage hub identification, full export, impact analysis, root cause analysis, downstream dashboard impact, and tag propagation across systems (Snowflake, Databricks, BigQuery) |
+| [Metadata Export Templates](references/metadata-export-templates.md) | SQL templates for exporting asset metadata to data marketplaces, AI applications, and reverse sync workflows — including basic export and custom metadata enrichment (Snowflake, Databricks, BigQuery) |
 | [Entity Metadata Reference](references/entity-metadata-reference.md) | ENTITY_METADATA namespace guide: supertype vs concrete tables, relationship tables, discovery |
 | [Usage Analytics Conventions](references/usage-analytics-conventions.md) | Critical conventions for usage analytics queries: domain handling, identity, noise filtering, session derivation, timezone, feature area mapping |
 | [Usage Analytics Templates](references/usage-analytics-templates.md) | SQL templates for schema profiling, active users (DAU/WAU/MAU), feature adoption, engagement depth, retention, and customer health scoring |

--- a/skills/atlan-lakehouse/references/lineage-templates.md
+++ b/skills/atlan-lakehouse/references/lineage-templates.md
@@ -1,0 +1,612 @@
+# Lineage SQL Templates
+
+All templates use `{{PLACEHOLDER}}` parameters. See the [SQL Template Reference](../SKILL.md#sql-template-reference) in the main skill file for parameter definitions.
+
+All templates are written in Snowflake SQL as the canonical dialect unless otherwise noted. **Agents should adapt syntax to the target engine on the fly.**
+
+> **Important — LINEAGE table:** These templates reference a `LINEAGE` table that is **not** part of the native GOLD namespace. It must be created separately in your warehouse. See [Set up lineage tables](https://docs.atlan.com/platform/lakehouse/references/set-up-lineage-tables). The `LINEAGE` table has columns: `start_guid`, `start_name`, `start_type`, `related_guid`, `related_name`, `related_type`, `direction` (`UPSTREAM` or `DOWNSTREAM`), `level` (hop depth, 1 = direct).
+
+---
+
+## 1. Assets Without Lineage
+
+Find orphaned or unused assets — active tables/views with no lineage that haven't been updated in 90+ days — for cleanup prioritization.
+
+```sql
+-- ASSETS WITHOUT LINEAGE: Find Orphaned/Unused Assets for Cleanup
+-- gold.assets: Lakehouse catalog (GOLD namespace)
+SELECT
+    a.guid,
+    a.asset_name,
+    a.asset_type,
+    a.asset_qualified_name,
+    a.connector_name,
+    a.description,
+    a.certificate_status,
+    a.status,
+    a.owner_users,
+    a.tags,
+    a.has_lineage,
+    TO_TIMESTAMP_LTZ(a.created_at / 1000) AS CREATED_DATE,
+    TO_TIMESTAMP_LTZ(a.updated_at / 1000) AS LAST_UPDATED,
+    DATEDIFF(day, TO_TIMESTAMP_LTZ(a.created_at / 1000), CURRENT_TIMESTAMP()) AS DAYS_SINCE_CREATION,
+    DATEDIFF(day, TO_TIMESTAMP_LTZ(a.updated_at / 1000), CURRENT_TIMESTAMP()) AS DAYS_SINCE_UPDATE,
+    CASE
+        WHEN a.certificate_status = 'DEPRECATED'
+        THEN '🔴 SAFE TO DELETE - Already deprecated'
+        WHEN DATEDIFF(day, TO_TIMESTAMP_LTZ(a.updated_at / 1000), CURRENT_TIMESTAMP()) > 180
+             AND a.status = 'ACTIVE'
+        THEN '🟡 REVIEW FOR DELETION - No activity in 6+ months'
+        WHEN DATEDIFF(day, TO_TIMESTAMP_LTZ(a.created_at / 1000), CURRENT_TIMESTAMP()) <= 7
+        THEN '🟢 KEEP - Recently created, may not be connected yet'
+        WHEN (a.owner_users IS NULL)
+        THEN '🟡 INVESTIGATE - No owner, likely test/temp asset'
+        ELSE '🟢 REVIEW - May be intentionally standalone'
+    END AS CLEANUP_RECOMMENDATION
+FROM {{DATABASE}}.GOLD.ASSETS a
+WHERE
+    a.has_lineage = FALSE
+    AND a.asset_type IN ('Table', 'View', 'MaterializedView')
+    AND a.status = 'ACTIVE'
+    AND a.connector_name IN ('snowflake', 'redshift', 'bigquery', 'databricks')
+    AND DATEDIFF(day, TO_TIMESTAMP_LTZ(a.updated_at / 1000), CURRENT_TIMESTAMP()) > 90
+ORDER BY DAYS_SINCE_UPDATE DESC, a.asset_name;
+```
+
+**BigQuery variant** — replace timestamp expressions:
+- `TO_TIMESTAMP_LTZ(a.created_at / 1000)` → `TIMESTAMP_MILLIS(CAST(a.created_at AS INT64))`
+- `DATEDIFF(day, ..., CURRENT_TIMESTAMP())` → `TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ..., DAY)`
+
+---
+
+## 2. Circular Dependencies
+
+Detect assets that appear in their own lineage path — self-referencing patterns that may indicate recursive queries or design issues.
+
+```sql
+-- CIRCULAR DEPENDENCIES: Find Assets with Lineage to Themselves
+-- gold.assets: Lakehouse catalog (GOLD namespace)
+-- LINEAGE: Customer-managed table
+SELECT
+    a.guid AS ASSET_GUID,
+    a.asset_name,
+    a.asset_type,
+    a.asset_qualified_name AS ASSET_PATH,
+    a.connector_name,
+    a.owner_users,
+    a.certificate_status,
+    TO_TIMESTAMP_LTZ(a.updated_at / 1000) AS LAST_UPDATED,
+    l.direction AS LINEAGE_DIRECTION,
+    l.level AS CIRCULAR_PATH_LENGTH,
+    l.related_name AS RELATED_ASSET_NAME,
+    l.related_type AS RELATED_ASSET_TYPE,
+    CASE
+        WHEN l.level = 1 THEN '⚠️ DIRECT SELF-REFERENCE - Review immediately'
+        WHEN l.level <= 3 THEN '⚠️ SHORT CIRCULAR PATH - May cause performance issues'
+        ELSE '⚠️ LONG CIRCULAR PATH - Complex dependency chain'
+    END AS CIRCULAR_DEPENDENCY_SEVERITY
+FROM {{DATABASE}}.GOLD.ASSETS a
+INNER JOIN LINEAGE l ON a.guid = l.start_guid
+WHERE
+    l.related_guid = a.guid  -- the lineage loops back to itself
+    AND a.asset_type IN ('Table', 'View', 'MaterializedView', 'DbtModel')
+    AND a.status = 'ACTIVE'
+ORDER BY l.level ASC, a.asset_name;
+```
+
+---
+
+## 3. Lineage Coverage Summary
+
+Platform-wide metrics on what percentage of active assets have lineage.
+
+```sql
+-- LINEAGE COVERAGE SUMMARY: Overall Platform Metrics
+SELECT
+    COUNT(*) AS TOTAL_ASSETS,
+    SUM(CASE WHEN has_lineage = TRUE THEN 1 ELSE 0 END) AS ASSETS_WITH_LINEAGE,
+    SUM(CASE WHEN has_lineage = FALSE THEN 1 ELSE 0 END) AS ASSETS_WITHOUT_LINEAGE,
+    ROUND(
+        (SUM(CASE WHEN has_lineage = TRUE THEN 1 ELSE 0 END) * 100.0) / COUNT(*), 2
+    ) AS LINEAGE_COVERAGE_PCT
+FROM {{DATABASE}}.GOLD.ASSETS
+WHERE status = 'ACTIVE';
+```
+
+## Lineage Coverage by Connector
+
+Break down lineage coverage per data platform and asset type.
+
+```sql
+-- LINEAGE COVERAGE BY CONNECTOR: Platform-Specific Metrics
+SELECT
+    connector_name,
+    asset_type,
+    COUNT(*) AS TOTAL_ASSETS,
+    SUM(CASE WHEN has_lineage = TRUE THEN 1 ELSE 0 END) AS WITH_LINEAGE,
+    SUM(CASE WHEN has_lineage = FALSE THEN 1 ELSE 0 END) AS WITHOUT_LINEAGE,
+    ROUND(
+        (SUM(CASE WHEN has_lineage = TRUE THEN 1 ELSE 0 END) * 100.0) / COUNT(*), 2
+    ) AS LINEAGE_COVERAGE_PCT
+FROM {{DATABASE}}.GOLD.ASSETS
+WHERE
+    status = 'ACTIVE'
+    AND NULLIF(connector_name, '') IS NOT NULL
+GROUP BY connector_name, asset_type
+ORDER BY connector_name, LINEAGE_COVERAGE_PCT DESC, TOTAL_ASSETS DESC;
+```
+
+---
+
+## 4. Identify Lineage Hubs (Most Connected Assets)
+
+Find the most critical tables/views — those with the highest number of direct upstream and downstream connections. Use for blast-radius assessment.
+
+```sql
+-- MOST CONNECTED ASSETS: Identify Critical Lineage Hubs
+-- Snowflake / Databricks
+SELECT
+    a.asset_name,
+    a.asset_type,
+    a.asset_qualified_name,
+    a.connector_name,
+    a.certificate_status,
+    a.owner_users,
+    TO_TIMESTAMP_LTZ(a.updated_at / 1000) AS LAST_UPDATED,
+    DATEDIFF(day, TO_TIMESTAMP_LTZ(a.updated_at / 1000), CURRENT_TIMESTAMP()) AS DAYS_SINCE_UPDATE,
+    COUNT(CASE WHEN l.direction = 'UPSTREAM' AND l.level = 1 THEN 1 END) AS UPSTREAM_COUNT,
+    COUNT(CASE WHEN l.direction = 'DOWNSTREAM' AND l.level = 1 THEN 1 END) AS DOWNSTREAM_COUNT,
+    COUNT(CASE WHEN l.level = 1 THEN 1 END) AS TOTAL_CONNECTIONS,
+    CASE
+        WHEN COUNT(CASE WHEN l.direction = 'DOWNSTREAM' AND l.level = 1 THEN 1 END) >= 20
+        THEN '🔴 CRITICAL - 20+ downstream dependencies'
+        WHEN COUNT(CASE WHEN l.direction = 'DOWNSTREAM' AND l.level = 1 THEN 1 END) >= 10
+        THEN '🟠 HIGH IMPACT - 10-19 downstream dependencies'
+        WHEN COUNT(CASE WHEN l.direction = 'DOWNSTREAM' AND l.level = 1 THEN 1 END) >= 5
+        THEN '🟡 MODERATE IMPACT - 5-9 downstream dependencies'
+        ELSE '🟢 LOW IMPACT - <5 downstream dependencies'
+    END AS CRITICALITY_LEVEL
+FROM {{DATABASE}}.GOLD.ASSETS a
+LEFT JOIN LINEAGE l ON a.guid = l.start_guid
+WHERE
+    a.has_lineage = TRUE
+    AND a.asset_type IN ('Table', 'View', 'MaterializedView')
+    AND a.status = 'ACTIVE'
+GROUP BY
+    a.asset_name, a.asset_type, a.asset_qualified_name,
+    a.connector_name, a.certificate_status, a.owner_users, a.updated_at
+HAVING COUNT(CASE WHEN l.level = 1 THEN 1 END) > 0
+ORDER BY TOTAL_CONNECTIONS DESC;
+```
+
+**BigQuery variant** — replace:
+- `TO_TIMESTAMP_LTZ(a.updated_at / 1000)` → `TIMESTAMP_MILLIS(a.updated_at)`
+- `DATEDIFF(day, ..., CURRENT_TIMESTAMP())` → `TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ..., DAY)`
+
+---
+
+## 5. Full Lineage Export
+
+Export the complete lineage graph for all recently-updated assets. Useful as a foundation for impact analysis, root cause analysis, and post-deployment validation.
+
+```sql
+-- FULL LINEAGE EXPORT
+-- Snowflake / Databricks
+SELECT
+    a.guid,
+    a.asset_name,
+    a.asset_qualified_name,
+    a.asset_type,
+    TO_TIMESTAMP_LTZ(a.updated_at / 1000) AS LAST_UPDATED,
+    DATEDIFF(day, TO_TIMESTAMP_LTZ(a.updated_at / 1000), CURRENT_TIMESTAMP()) AS DAYS_SINCE_UPDATE,
+    l.start_name,
+    l.start_type,
+    l.related_name,
+    l.related_type,
+    l.direction,
+    l.level
+FROM {{DATABASE}}.GOLD.ASSETS a
+INNER JOIN LINEAGE l ON a.guid = l.start_guid
+WHERE
+    a.has_lineage
+    AND a.connector_name IN ('snowflake', 'redshift', 'bigquery')
+    AND DATEDIFF(day, TO_TIMESTAMP_LTZ(a.updated_at / 1000), CURRENT_TIMESTAMP()) <= 2
+GROUP BY
+    a.guid, a.asset_name, a.asset_qualified_name, a.asset_type, a.updated_at,
+    l.start_name, l.start_type, l.related_name, l.related_type, l.direction, l.level
+ORDER BY a.updated_at DESC, a.asset_qualified_name, l.direction, l.level
+LIMIT 200;
+```
+
+**BigQuery variant:**
+```sql
+-- FULL LINEAGE EXPORT — BigQuery
+SELECT
+    a.guid,
+    a.asset_name,
+    a.asset_qualified_name,
+    a.asset_type,
+    TIMESTAMP_MILLIS(CAST(a.updated_at AS INT64)) AS LAST_UPDATED,
+    TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), TIMESTAMP_MILLIS(CAST(a.updated_at AS INT64)), DAY) AS DAYS_SINCE_UPDATE,
+    l.start_name,
+    l.start_type,
+    l.related_name,
+    l.related_type,
+    l.direction,
+    l.level
+FROM {{DATABASE}}.GOLD.ASSETS a
+JOIN LINEAGE l ON a.guid = l.start_guid
+WHERE
+    a.has_lineage
+    AND a.connector_name IN ('snowflake', 'redshift', 'bigquery')
+    AND TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), TIMESTAMP_MILLIS(CAST(a.updated_at AS INT64)), DAY) <= 2
+ORDER BY a.updated_at DESC, a.asset_qualified_name, l.direction, l.level
+LIMIT 200;
+```
+
+---
+
+## 6. Lineage Impact Analysis
+
+Before making changes to a table — renaming columns, deprecating assets, changing types, migrating schemas — find all downstream dependencies and their owners to notify.
+
+```sql
+-- IMPACT ANALYSIS: Find All Downstream Dependencies Before Making Changes
+-- Snowflake
+SELECT
+    a.asset_name AS SOURCE_ASSET,
+    a.asset_type AS SOURCE_TYPE,
+    a.asset_qualified_name AS SOURCE_PATH,
+    a.certificate_status AS SOURCE_CERT,
+    TO_TIMESTAMP_LTZ(a.updated_at / 1000) AS SOURCE_LAST_UPDATED,
+    l.related_name AS IMPACTED_ASSET,
+    l.related_type AS IMPACTED_TYPE,
+    l.level AS DEPENDENCY_DEPTH,
+    ra.asset_qualified_name AS IMPACTED_PATH,
+    ra.owner_users AS IMPACTED_OWNERS,
+    ra.connector_name AS IMPACTED_SYSTEM,
+    ra.certificate_status AS IMPACTED_CERT_STATUS,
+    TO_TIMESTAMP_LTZ(ra.updated_at / 1000) AS IMPACTED_LAST_UPDATED,
+    CASE
+        WHEN l.level = 1 THEN 'DIRECT DEPENDENCY - HIGH PRIORITY'
+        WHEN l.level = 2 THEN 'SECONDARY DEPENDENCY - MEDIUM PRIORITY'
+        ELSE 'INDIRECT DEPENDENCY - LOW PRIORITY'
+    END AS NOTIFICATION_PRIORITY
+FROM {{DATABASE}}.GOLD.ASSETS a
+INNER JOIN LINEAGE l ON a.guid = l.start_guid
+LEFT JOIN {{DATABASE}}.GOLD.ASSETS ra ON l.related_guid = ra.guid
+WHERE
+    -- 🔧 CUSTOMIZE: replace with the qualified name or GUID of the asset you're changing
+    a.asset_qualified_name = 'default/snowflake/123/ANALYTICS/DIM_CUSTOMERS'
+    AND a.asset_type = 'Table'
+    AND l.direction = 'DOWNSTREAM'
+ORDER BY l.level ASC, l.related_type, l.related_name;
+```
+
+**BigQuery variant** — filter by GUID and replace timestamp expressions:
+```sql
+-- IMPACT ANALYSIS — BigQuery
+SELECT
+    a.asset_name AS SOURCE_ASSET,
+    a.asset_type AS SOURCE_TYPE,
+    a.asset_qualified_name AS SOURCE_PATH,
+    a.certificate_status AS SOURCE_CERT,
+    TIMESTAMP_MILLIS(a.updated_at) AS SOURCE_LAST_UPDATED,
+    l.related_name AS IMPACTED_ASSET,
+    l.related_type AS IMPACTED_TYPE,
+    l.level AS DEPENDENCY_DEPTH,
+    ra.asset_qualified_name AS IMPACTED_PATH,
+    ra.owner_users AS IMPACTED_OWNERS,
+    ra.connector_name AS IMPACTED_SYSTEM,
+    ra.certificate_status AS IMPACTED_CERT_STATUS,
+    TIMESTAMP_MILLIS(ra.updated_at) AS IMPACTED_LAST_UPDATED,
+    CASE
+        WHEN l.level = 1 THEN 'DIRECT DEPENDENCY - HIGH PRIORITY'
+        WHEN l.level = 2 THEN 'SECONDARY DEPENDENCY - MEDIUM PRIORITY'
+        ELSE 'INDIRECT DEPENDENCY - LOW PRIORITY'
+    END AS NOTIFICATION_PRIORITY
+FROM {{DATABASE}}.GOLD.ASSETS a
+INNER JOIN LINEAGE l ON a.guid = l.start_guid
+LEFT JOIN {{DATABASE}}.GOLD.ASSETS ra ON l.related_guid = ra.guid
+WHERE
+    a.guid = 'ff0f00d5-dde5-4cf9-b199-2ab09a961bd2'  -- 🔧 replace with asset GUID
+    AND l.direction = 'DOWNSTREAM'
+ORDER BY l.level ASC, l.related_type, l.related_name;
+```
+
+---
+
+## 7. Lineage Root Cause Analysis
+
+Trace data quality issues backward through the pipeline to identify upstream sources contributing to the problem. Results are ordered by hop distance (closest sources first).
+
+```sql
+-- ROOT CAUSE ANALYSIS: Trace Upstream to Find Problem Sources
+-- Snowflake / Databricks / BigQuery (same query, adjust timestamp functions)
+SELECT
+    a.asset_name AS PROBLEM_ASSET,
+    a.asset_type AS PROBLEM_ASSET_TYPE,
+    a.asset_qualified_name AS PROBLEM_ASSET_PATH,
+    a.owner_users AS PROBLEM_ASSET_OWNERS,
+    l.related_name AS UPSTREAM_ASSET,
+    l.related_type AS UPSTREAM_ASSET_TYPE,
+    l.level AS HOPS_FROM_PROBLEM,
+    ra.asset_qualified_name AS UPSTREAM_QUALIFIED_NAME,
+    ra.owner_users AS UPSTREAM_OWNERS,
+    ra.certificate_status AS UPSTREAM_CERT_STATUS,
+    ra.connector_name AS UPSTREAM_CONNECTOR
+FROM {{DATABASE}}.GOLD.ASSETS a
+INNER JOIN LINEAGE l ON a.guid = l.start_guid
+LEFT JOIN {{DATABASE}}.GOLD.ASSETS ra ON l.related_guid = ra.guid
+WHERE
+    a.guid = 'ff0f00d5-dde5-4cf9-b199-2ab09a961bd2'  -- 🔧 replace with the problem asset's GUID
+    AND l.direction = 'UPSTREAM'
+    AND l.level <= 5
+    AND l.related_type IN ('Table', 'View', 'MaterializedView', 'Column')
+ORDER BY l.level ASC, l.related_name;
+```
+
+---
+
+## 8. Downstream Impacted Dashboards
+
+Before modifying a source table or view, identify every BI dashboard downstream — across Tableau, Power BI, Looker, Thoughtspot, MicroStrategy, Qlik, and Sigma — along with impact severity and recommended actions.
+
+```sql
+-- DOWNSTREAM DASHBOARD IMPACT: Find All BI Dashboards Affected by Data Changes
+-- Snowflake
+SELECT
+    a.asset_name AS SOURCE_DATA_ASSET,
+    a.asset_type AS SOURCE_TYPE,
+    a.asset_qualified_name AS SOURCE_PATH,
+    TO_TIMESTAMP_LTZ(a.updated_at / 1000) AS SOURCE_LAST_UPDATED,
+    l.level AS HOPS_TO_DASHBOARD,
+    l.related_name AS IMPACTED_DASHBOARD_NAME,
+    l.related_type AS IMPACTED_DASHBOARD_TYPE,
+    ra.asset_qualified_name AS IMPACTED_DASHBOARD_PATH,
+    ra.owner_users AS DASHBOARD_OWNERS,
+    ra.description AS DASHBOARD_DESCRIPTION,
+    TO_TIMESTAMP_LTZ(ra.updated_at / 1000) AS DASHBOARD_LAST_UPDATED,
+    DATEDIFF(day, TO_TIMESTAMP_LTZ(ra.updated_at / 1000), CURRENT_TIMESTAMP()) AS DAYS_SINCE_DASHBOARD_UPDATE,
+    CASE
+        WHEN l.level = 1 THEN '🔴 DIRECT - Will break immediately'
+        WHEN l.level = 2 THEN '🟡 INDIRECT - May break through intermediate assets'
+        ELSE '🟢 DISTANT - Lower risk but monitor'
+    END AS IMPACT_SEVERITY,
+    CASE
+        WHEN l.level = 1 THEN 'Update dashboard queries before deployment'
+        WHEN l.level = 2 THEN 'Test dashboard after deployment'
+        ELSE 'Monitor dashboard post-deployment'
+    END AS RECOMMENDED_ACTION
+FROM {{DATABASE}}.GOLD.ASSETS a
+INNER JOIN LINEAGE l ON a.guid = l.start_guid
+LEFT JOIN {{DATABASE}}.GOLD.ASSETS ra ON l.related_guid = ra.guid
+WHERE
+    a.guid = 'ff0f00d5-dde5-4cf9-b199-2ab09a961bd2'  -- 🔧 replace with source table GUID
+    AND l.direction = 'DOWNSTREAM'
+    AND l.related_type IN (
+        'TableauDashboard', 'TableauWorkbook', 'TableauWorksheet',
+        'PowerBIDashboard', 'PowerBIReport', 'PowerBIDataset',
+        'LookerDashboard', 'LookerLook',
+        'ThoughtspotLiveboard', 'ThoughtspotAnswer',
+        'MicroStrategyDossier', 'QlikApp', 'SigmaWorkbook'
+    )
+    AND l.level <= 3
+ORDER BY l.level ASC, l.related_type, l.related_name;
+```
+
+**Databricks / BigQuery** — same query; replace timestamp functions:
+- Databricks: `from_unixtime(a.updated_at / 1000)`, `datediff(CURRENT_DATE(), ...)`
+- BigQuery: `TIMESTAMP_MILLIS(a.updated_at)`, `TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ..., DAY)`
+
+---
+
+## 9. Tag Propagation Across Lineage
+
+Measure how governance tags (PII, Confidential, Finance, etc.) flow from tagged upstream assets to all downstream consumers. Identify where tags are dropped, partially propagated, or replaced.
+
+### Snowflake
+
+```sql
+-- TAG PROPAGATION ANALYSIS — Snowflake
+WITH tagged_sources AS (
+    SELECT
+        guid, asset_name, asset_type, asset_qualified_name, connector_name,
+        tags, certificate_status, owner_users,
+        TO_TIMESTAMP_LTZ(updated_at / 1000) AS LAST_UPDATED
+    FROM {{DATABASE}}.GOLD.ASSETS
+    WHERE
+        status = 'ACTIVE'
+        AND connector_name = 'snowflake'  -- 🔧 CUSTOMIZE: your connector(s)
+        AND tags IS NOT NULL
+        AND ARRAY_SIZE(tags) > 0
+        AND (
+            ARRAY_CONTAINS('PII'::VARIANT, tags)
+            OR ARRAY_CONTAINS('Confidential'::VARIANT, tags)
+            OR ARRAY_CONTAINS('Finance'::VARIANT, tags)
+            OR ARRAY_CONTAINS('Cost_center'::VARIANT, tags)
+        )
+),
+downstream_lineage AS (
+    SELECT
+        ts.guid AS SOURCE_GUID, ts.asset_name AS SOURCE_NAME, ts.asset_type AS SOURCE_TYPE,
+        ts.connector_name AS SOURCE_CONNECTOR, ts.tags AS SOURCE_TAGS,
+        l.related_guid AS DOWNSTREAM_GUID, l.related_name AS DOWNSTREAM_NAME,
+        l.related_type AS DOWNSTREAM_TYPE, l.level AS LINEAGE_DEPTH,
+        ra.tags AS DOWNSTREAM_TAGS, ra.connector_name AS DOWNSTREAM_CONNECTOR
+    FROM tagged_sources ts
+    INNER JOIN LINEAGE l ON ts.guid = l.start_guid
+    LEFT JOIN {{DATABASE}}.GOLD.ASSETS ra ON l.related_guid = ra.guid
+    WHERE l.direction = 'DOWNSTREAM'
+)
+SELECT
+    SOURCE_NAME, SOURCE_TYPE, SOURCE_CONNECTOR, SOURCE_TAGS,
+    LINEAGE_DEPTH, DOWNSTREAM_NAME, DOWNSTREAM_TYPE, DOWNSTREAM_CONNECTOR, DOWNSTREAM_TAGS,
+    CASE
+        WHEN DOWNSTREAM_TAGS IS NULL OR ARRAY_SIZE(DOWNSTREAM_TAGS) = 0
+        THEN '🔴 NO tags - Complete tag drop'
+        WHEN ARRAYS_OVERLAP(SOURCE_TAGS, DOWNSTREAM_TAGS)
+        THEN '🟢 tags PROPAGATED - Some or all tags present'
+        ELSE '🟡 DIFFERENT tags - Tagged but not inherited from source'
+    END AS TAG_PROPAGATION_STATUS,
+    ARRAY_EXCEPT(SOURCE_TAGS, COALESCE(DOWNSTREAM_TAGS, ARRAY_CONSTRUCT())) AS DROPPED_TAGS,
+    CASE
+        WHEN DOWNSTREAM_TAGS IS NOT NULL AND ARRAY_SIZE(DOWNSTREAM_TAGS) > 0
+        THEN ROUND(
+            (ARRAY_SIZE(ARRAY_INTERSECTION(SOURCE_TAGS, DOWNSTREAM_TAGS)) * 100.0) / ARRAY_SIZE(SOURCE_TAGS), 2
+        )
+        ELSE 0
+    END AS TAG_INHERITANCE_PCT
+FROM downstream_lineage
+ORDER BY SOURCE_NAME, LINEAGE_DEPTH, DOWNSTREAM_NAME;
+```
+
+### Databricks
+
+```sql
+-- TAG PROPAGATION ANALYSIS — Databricks
+WITH tagged_sources AS (
+    SELECT
+        guid, asset_name, asset_type, asset_qualified_name, connector_name,
+        tags, certificate_status, owner_users,
+        from_unixtime(updated_at / 1000) AS LAST_UPDATED
+    FROM {{DATABASE}}.GOLD.ASSETS
+    WHERE
+        status = 'ACTIVE'
+        AND connector_name = 'snowflake'  -- 🔧 CUSTOMIZE
+        AND tags IS NOT NULL
+        AND size(tags) > 0
+        AND (
+            array_contains(tags, 'PII')
+            OR array_contains(tags, 'Confidential')
+            OR array_contains(tags, 'Finance')
+            OR array_contains(tags, 'Cost_center')
+        )
+),
+downstream_lineage AS (
+    SELECT
+        ts.guid AS SOURCE_GUID, ts.asset_name AS SOURCE_NAME, ts.asset_type AS SOURCE_TYPE,
+        ts.connector_name AS SOURCE_CONNECTOR, ts.tags AS SOURCE_TAGS,
+        ts.last_updated AS SOURCE_LAST_UPDATED,
+        l.related_guid AS DOWNSTREAM_GUID, l.related_name AS DOWNSTREAM_NAME,
+        l.related_type AS DOWNSTREAM_TYPE, l.level AS LINEAGE_DEPTH,
+        ra.tags AS DOWNSTREAM_TAGS, ra.connector_name AS DOWNSTREAM_CONNECTOR,
+        ra.asset_qualified_name AS DOWNSTREAM_QUALIFIED_NAME,
+        ra.owner_users AS DOWNSTREAM_OWNERS, ra.certificate_status AS DOWNSTREAM_CERT,
+        from_unixtime(ra.updated_at / 1000) AS DOWNSTREAM_LAST_UPDATED,
+        datediff(CURRENT_DATE(), from_unixtime(ra.updated_at / 1000)) AS DOWNSTREAM_DAYS_SINCE_UPDATE
+    FROM tagged_sources ts
+    INNER JOIN LINEAGE l ON ts.guid = l.start_guid
+    LEFT JOIN {{DATABASE}}.GOLD.ASSETS ra ON l.related_guid = ra.guid
+    WHERE l.direction = 'DOWNSTREAM'
+)
+SELECT
+    SOURCE_NAME, SOURCE_TYPE, SOURCE_CONNECTOR, SOURCE_TAGS, SOURCE_LAST_UPDATED,
+    LINEAGE_DEPTH, DOWNSTREAM_NAME, DOWNSTREAM_TYPE, DOWNSTREAM_CONNECTOR,
+    DOWNSTREAM_QUALIFIED_NAME, DOWNSTREAM_TAGS, DOWNSTREAM_OWNERS, DOWNSTREAM_CERT,
+    DOWNSTREAM_LAST_UPDATED, DOWNSTREAM_DAYS_SINCE_UPDATE,
+    CASE
+        WHEN DOWNSTREAM_TAGS IS NULL OR size(DOWNSTREAM_TAGS) = 0
+        THEN '🔴 NO tags - Complete tag drop'
+        WHEN arrays_overlap(SOURCE_TAGS, DOWNSTREAM_TAGS)
+        THEN '🟢 tags PROPAGATED - Some or all tags present'
+        ELSE '🟡 DIFFERENT tags - Tagged but not inherited from source'
+    END AS TAG_PROPAGATION_STATUS,
+    array_except(SOURCE_TAGS, COALESCE(DOWNSTREAM_TAGS, array())) AS DROPPED_TAGS,
+    array_except(COALESCE(DOWNSTREAM_TAGS, array()), SOURCE_TAGS) AS NEW_TAGS_ADDED,
+    CASE
+        WHEN DOWNSTREAM_TAGS IS NOT NULL AND size(DOWNSTREAM_TAGS) > 0
+        THEN ROUND(
+            (size(array_intersect(SOURCE_TAGS, DOWNSTREAM_TAGS)) * 100.0) / size(SOURCE_TAGS), 2
+        )
+        ELSE 0
+    END AS TAG_INHERITANCE_PCT
+FROM downstream_lineage
+ORDER BY SOURCE_NAME, LINEAGE_DEPTH, DOWNSTREAM_NAME;
+```
+
+### BigQuery
+
+```sql
+-- TAG PROPAGATION ANALYSIS — BigQuery
+WITH tagged_sources AS (
+    SELECT
+        guid, asset_name, asset_type, asset_qualified_name, connector_name,
+        tags, certificate_status, owner_users
+    FROM {{DATABASE}}.GOLD.ASSETS
+    WHERE
+        status = 'ACTIVE'
+        AND connector_name = 'snowflake'  -- 🔧 CUSTOMIZE
+        AND tags IS NOT NULL
+        AND ARRAY_LENGTH(tags) > 0
+        AND (
+            'PII' IN UNNEST(tags)
+            OR 'Confidential' IN UNNEST(tags)
+            OR 'Finance' IN UNNEST(tags)
+            OR 'Cost_center' IN UNNEST(tags)
+        )
+),
+downstream_lineage AS (
+    SELECT
+        ts.guid AS SOURCE_GUID, ts.asset_name AS SOURCE_NAME, ts.asset_type AS SOURCE_TYPE,
+        ts.connector_name AS SOURCE_CONNECTOR, ts.tags AS SOURCE_TAGS,
+        l.related_guid AS DOWNSTREAM_GUID, l.related_name AS DOWNSTREAM_NAME,
+        l.related_type AS DOWNSTREAM_TYPE, l.level AS LINEAGE_DEPTH,
+        ra.tags AS DOWNSTREAM_TAGS, ra.connector_name AS DOWNSTREAM_CONNECTOR
+    FROM tagged_sources ts
+    INNER JOIN LINEAGE l ON ts.guid = l.start_guid
+    LEFT JOIN {{DATABASE}}.GOLD.ASSETS ra ON l.related_guid = ra.guid
+    WHERE l.direction = 'DOWNSTREAM'
+)
+SELECT
+    SOURCE_NAME, SOURCE_TYPE, SOURCE_CONNECTOR, SOURCE_TAGS,
+    LINEAGE_DEPTH, DOWNSTREAM_NAME, DOWNSTREAM_TYPE, DOWNSTREAM_CONNECTOR, DOWNSTREAM_TAGS,
+    CASE
+        WHEN DOWNSTREAM_TAGS IS NULL OR ARRAY_LENGTH(DOWNSTREAM_TAGS) = 0
+        THEN '🔴 NO tags - Complete tag drop'
+        WHEN EXISTS (
+            SELECT 1 FROM UNNEST(SOURCE_TAGS) AS st WHERE st IN UNNEST(DOWNSTREAM_TAGS)
+        )
+        THEN '🟢 tags PROPAGATED - Some or all tags present'
+        ELSE '🟡 DIFFERENT tags - Tagged but not inherited from source'
+    END AS TAG_PROPAGATION_STATUS,
+    ARRAY(
+        SELECT st FROM UNNEST(SOURCE_TAGS) AS st
+        WHERE st NOT IN (SELECT dt FROM UNNEST(IFNULL(DOWNSTREAM_TAGS, [])) AS dt)
+    ) AS DROPPED_TAGS,
+    CASE
+        WHEN DOWNSTREAM_TAGS IS NOT NULL AND ARRAY_LENGTH(DOWNSTREAM_TAGS) > 0
+        THEN ROUND(
+            (ARRAY_LENGTH(ARRAY(
+                SELECT st FROM UNNEST(SOURCE_TAGS) AS st
+                WHERE st IN (SELECT dt FROM UNNEST(DOWNSTREAM_TAGS) AS dt)
+            )) * 100.0) / ARRAY_LENGTH(SOURCE_TAGS), 2
+        )
+        ELSE 0
+    END AS TAG_INHERITANCE_PCT
+FROM downstream_lineage
+ORDER BY SOURCE_NAME, LINEAGE_DEPTH, DOWNSTREAM_NAME;
+```
+
+### Common customization filters
+
+Add to `tagged_sources` WHERE clause to narrow results:
+
+```sql
+-- Filter by multiple connectors
+AND connector_name IN ('snowflake', 'bigquery', 'databricks')
+
+-- Filter by certification status
+AND certificate_status = 'VERIFIED'
+
+-- Filter by specific asset types
+AND asset_type IN ('Table', 'View', 'MaterializedView')
+
+-- Filter by time window (last 90 days)
+-- Snowflake: AND TO_TIMESTAMP_LTZ(updated_at / 1000) >= DATEADD(day, -90, CURRENT_DATE())
+-- Databricks: AND FROM_UNIXTIME(updated_at / 1000) >= DATE_SUB(CURRENT_DATE(), 90)
+-- BigQuery:   AND TIMESTAMP_MILLIS(updated_at) >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+
+-- Limit lineage depth (add to final SELECT WHERE clause)
+WHERE LINEAGE_DEPTH <= 3
+```

--- a/skills/atlan-lakehouse/references/metadata-export-templates.md
+++ b/skills/atlan-lakehouse/references/metadata-export-templates.md
@@ -1,0 +1,255 @@
+# Metadata Export SQL Templates
+
+Templates for exporting enriched asset metadata from the Atlan Lakehouse to power AI applications, data marketplaces, reverse sync workflows, and governance dashboards.
+
+All templates use `{{PLACEHOLDER}}` parameters. See the [SQL Template Reference](../SKILL.md#sql-template-reference) in the main skill file for parameter definitions.
+
+> **Namespaces used:** `GOLD.ASSETS` (core asset data), `ENTITY_METADATA.Readme` (README content), `ENTITY_METADATA.TagRelationship` (tags), `ENTITY_METADATA.CustomMetadata` (custom metadata attributes).
+
+---
+
+## 1. Basic Asset Metadata Export
+
+Export core asset metadata — descriptions, certification, owners, tags, README, popularity, and lineage flag — for downstream tools such as data marketplaces or AI search indexes.
+
+```sql
+-- ASSET METADATA EXPORT: Core attributes with README and tags
+-- Snowflake
+USE {{DATABASE}};
+SELECT
+    A.asset_name,
+    A.guid,
+    A.asset_qualified_name,
+    A.asset_type,
+    A.description,
+    A.user_description,
+    A.status,
+    A.certificate_status,
+    A.owner_users,
+    tr.TAGS,
+    R.description AS README_TEXT,
+    A.popularity_score,
+    A.has_lineage
+FROM {{DATABASE}}.GOLD.ASSETS A
+LEFT JOIN {{DATABASE}}.ENTITY_METADATA.Readme R ON A.readme_guid = R.GUID
+LEFT JOIN (
+    SELECT guid, ARRAY_AGG(tagName) AS TAGS
+    FROM {{DATABASE}}.ENTITY_METADATA.TagRelationship
+    WHERE status = 'ACTIVE'
+    GROUP BY guid
+) tr ON A.guid = tr.guid
+WHERE
+    A.asset_type IN ('Table', 'Column', 'View')
+    AND A.connector_name IN ('snowflake', 'redshift', 'bigquery')
+    AND R.description IS NOT NULL  -- only assets with README documentation
+LIMIT 10;
+```
+
+---
+
+## 2. Asset Enrichment with Custom Metadata
+
+Export assets enriched with a named custom metadata set (e.g., "AI Readiness" scores). Useful for building data product catalogs or readiness dashboards.
+
+### Snowflake
+
+```sql
+-- ASSET ENRICHMENT WITH CUSTOM METADATA SCORES — Snowflake
+USE {{DATABASE}};
+WITH CM_DETAILS AS (
+    SELECT
+        CM.GUID,
+        PARSE_JSON(
+            '{' ||
+            LISTAGG(
+                '"' || CM.attributeName || '":"' ||
+                REPLACE(COALESCE(CM.attributeValue, ''), '"', '\\"') || '"',
+                ','
+            ) WITHIN GROUP (ORDER BY CM.attributeName)
+            || '}'
+        ) AS CM_ATTRIBUTES_JSON
+    FROM {{DATABASE}}.ENTITY_METADATA.CustomMetadata CM
+    WHERE
+        CM.STATUS = 'ACTIVE'
+        AND CM.customMetadataSetName = 'AI Readiness'  -- 🔧 CUSTOMIZE: your CM set name
+        AND CM.attributeValue IS NOT NULL
+    GROUP BY CM.GUID
+)
+SELECT
+    A.asset_name,
+    A.guid,
+    A.asset_qualified_name,
+    A.asset_type,
+    A.description,
+    A.user_description,
+    R.description AS README_TEXT,
+    A.status,
+    A.certificate_status,
+    A.owner_users,
+    tr.TAGS,
+    A.popularity_score,
+    A.has_lineage,
+    CMS.CM_ATTRIBUTES_JSON
+FROM {{DATABASE}}.GOLD.ASSETS A
+LEFT JOIN {{DATABASE}}.ENTITY_METADATA.Readme R ON A.readme_guid = R.GUID
+LEFT JOIN CM_DETAILS CMS ON A.guid = CMS.GUID
+LEFT JOIN (
+    SELECT guid, ARRAY_AGG(tagName) AS TAGS
+    FROM {{DATABASE}}.ENTITY_METADATA.TagRelationship
+    WHERE status = 'ACTIVE'
+    GROUP BY guid
+) tr ON A.guid = tr.guid
+WHERE
+    A.asset_type IN ('Table', 'Column', 'View')
+    AND A.connector_name IN ('snowflake', 'redshift', 'bigquery')
+    AND A.status = 'ACTIVE'
+    AND CMS.CM_ATTRIBUTES_JSON IS NOT NULL
+    AND A.owner_users IS NOT NULL
+LIMIT 5;
+```
+
+### Databricks
+
+```sql
+-- ASSET ENRICHMENT WITH CUSTOM METADATA SCORES — Databricks
+WITH CM_JSON AS (
+    SELECT
+        CM.GUID,
+        collect_list(CM.attributeName) AS SCORE_ATTRIBUTE_NAMES,
+        collect_list(CM.attributeValue) AS SCORE_ATTRIBUTE_VALUES,
+        concat(
+            '{',
+            concat_ws(
+                ',',
+                collect_list(
+                    concat(
+                        '"', CM.attributeName, '":"',
+                        regexp_replace(coalesce(CM.attributeValue, ''), '"', '\\\\"'), '"'
+                    )
+                )
+            ),
+            '}'
+        ) AS CM_ATTRIBUTES_JSON
+    FROM {{DATABASE}}.ENTITY_METADATA.CustomMetadata CM
+    WHERE
+        CM.STATUS = 'ACTIVE'
+        AND CM.customMetadataSetName = 'AI Readiness'  -- 🔧 CUSTOMIZE
+        AND CM.attributeValue IS NOT NULL
+    GROUP BY CM.GUID
+)
+SELECT
+    A.asset_name,
+    A.guid,
+    A.asset_qualified_name,
+    A.asset_type,
+    A.description,
+    A.user_description,
+    R.description AS README_TEXT,
+    A.status,
+    A.certificate_status,
+    A.owner_users,
+    tr.TAGS,
+    A.popularity_score,
+    A.has_lineage,
+    CMS.CM_ATTRIBUTES_JSON
+FROM {{DATABASE}}.GOLD.ASSETS A
+LEFT JOIN {{DATABASE}}.ENTITY_METADATA.Readme R ON A.readme_guid = R.GUID
+LEFT JOIN CM_JSON CMS ON A.guid = CMS.GUID
+LEFT JOIN (
+    SELECT guid, collect_list(tagName) AS TAGS
+    FROM {{DATABASE}}.ENTITY_METADATA.TagRelationship
+    WHERE status = 'ACTIVE'
+    GROUP BY guid
+) tr ON A.guid = tr.guid
+WHERE
+    A.connector_name IN ('snowflake', 'redshift', 'bigquery', 'oracle')
+    AND A.status = 'ACTIVE'
+    AND CMS.CM_ATTRIBUTES_JSON IS NOT NULL
+    AND A.owner_users IS NOT NULL
+    AND size(A.owner_users) > 0
+LIMIT 10;
+```
+
+### BigQuery
+
+```sql
+-- ASSET ENRICHMENT WITH CUSTOM METADATA SCORES — BigQuery
+WITH CM_JSON AS (
+    SELECT
+        CM.GUID,
+        PARSE_JSON(
+            CONCAT(
+                '{',
+                STRING_AGG(
+                    CONCAT('"', CM.attributeName, '":"', IFNULL(CM.attributeValue, ''), '"'),
+                    ',' ORDER BY CM.attributeName
+                ),
+                '}'
+            )
+        ) AS CM_ATTRIBUTES_JSON
+    FROM {{DATABASE}}.ENTITY_METADATA.CustomMetadata CM
+    WHERE
+        CM.STATUS = 'ACTIVE'
+        AND CM.customMetadataSetName = 'AI Readiness'  -- 🔧 CUSTOMIZE
+    GROUP BY CM.GUID
+)
+SELECT
+    A.asset_name,
+    A.guid,
+    A.asset_qualified_name,
+    A.asset_type,
+    A.description,
+    A.user_description,
+    R.description AS README_TEXT,
+    A.status,
+    A.certificate_status,
+    A.owner_users,
+    tr.TAGS,
+    A.popularity_score,
+    A.has_lineage,
+    CMS.CM_ATTRIBUTES_JSON,
+    -- Extract specific attributes from the JSON
+    JSON_EXTRACT_SCALAR(CMS.CM_ATTRIBUTES_JSON, '$.data_quality_score') AS data_quality_score,
+    JSON_EXTRACT_SCALAR(CMS.CM_ATTRIBUTES_JSON, '$.ai_readiness_score') AS ai_readiness_score
+FROM {{DATABASE}}.GOLD.ASSETS A
+LEFT JOIN {{DATABASE}}.ENTITY_METADATA.Readme R ON A.readme_guid = R.GUID
+LEFT JOIN CM_JSON CMS ON A.guid = CMS.GUID
+LEFT JOIN (
+    SELECT guid, ARRAY_AGG(tagName) AS TAGS
+    FROM {{DATABASE}}.ENTITY_METADATA.TagRelationship
+    WHERE status = 'ACTIVE'
+    GROUP BY guid
+) tr ON A.guid = tr.guid
+WHERE
+    A.connector_name IN ('snowflake', 'redshift', 'bigquery', 'oracle')
+    AND A.status = 'ACTIVE'
+    AND CMS.CM_ATTRIBUTES_JSON IS NOT NULL
+    AND A.owner_users IS NOT NULL
+    AND ARRAY_LENGTH(A.owner_users) > 0
+LIMIT 10;
+```
+
+---
+
+## Common Customizations
+
+```sql
+-- Broaden to all certified assets (not just those with README)
+-- Remove: AND R.description IS NOT NULL
+
+-- Narrow to a single connector
+AND A.connector_name = 'snowflake'
+
+-- Include only verified/certified assets
+AND A.certificate_status = 'VERIFIED'
+
+-- Include assets with high popularity
+AND A.popularity_score > 0.5
+
+-- Include all asset types (not just Table/Column/View)
+-- Remove the asset_type filter entirely, or expand:
+AND A.asset_type IN ('Table', 'Column', 'View', 'Dashboard', 'AtlasGlossaryTerm')
+
+-- Change the custom metadata set name
+AND CM.customMetadataSetName = 'Data Governance'  -- 🔧 replace with your set name
+```


### PR DESCRIPTION
## Summary

- **Updated** `skills/atlan-lakehouse/SKILL.md` (v1.0 → v1.1) — added 10 new lineage use cases to \"When to Use\", new query planning step for LINEAGE table routing, and reference table entries for the two new files
- **Added** `references/lineage-templates.md` — 9 SQL templates covering: assets without lineage, circular dependencies, coverage summary, coverage by connector, lineage hub assets, full export, impact analysis, root cause analysis, downstream dashboard impact, tag propagation (Snowflake canonical + BigQuery/Databricks variants)
- **Added** `references/metadata-export-templates.md` — SQL templates for core asset metadata export and enrichment with custom metadata

## Context

These skills are consumed by the Atlan conversational search backend (wisdom) to answer questions about lineage and metadata governance. Companion PR in wisdom: `atlanhq/wisdom#feat/mdlh-skills-seed`.

## Test plan

- [ ] Verify SQL templates execute correctly against a Snowflake Iceberg lakehouse
- [ ] Verify BigQuery/Databricks variant notes are accurate for each template
- [ ] Confirm LINEAGE table schema matches documented columns (`start_guid`, `related_guid`, `direction`, `level`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)