### PR TITLE
fix: handle readIcebergEnabled config not available on newer Databricks runtimes

### DIFF
--- a/databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_create.py
+++ b/databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_create.py
@@ -115,7 +115,15 @@ def main():
     logger.info("Starting Polaris → Unity Catalog sync")
 
     spark = SparkSession.builder.getOrCreate()
-    spark.conf.set("spark.databricks.delta.uniform.readIcebergEnabled", "true")
+    try:
+        spark.conf.set("spark.databricks.delta.uniform.readIcebergEnabled", "true")
+    except Exception:
+        logger.info(
+            "spark.databricks.delta.uniform.readIcebergEnabled is not available on this "
+            "Databricks Runtime. This is expected on runtimes where the feature has been "
+            "renamed to 'Read Iceberg Via Metadata Location' and is enabled at the "
+            "workspace level. Continuing without setting the config."
+        )
 
     reader = PolarisSQLReader()
     namespaces = reader.list_namespaces()

--- a/databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_refresh.py
+++ b/databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_refresh.py
@@ -115,7 +115,15 @@ def main():
     logger.info("Starting Polaris → Unity Catalog sync")
 
     spark = SparkSession.builder.getOrCreate()
-    spark.conf.set("spark.databricks.delta.uniform.readIcebergEnabled", "true")
+    try:
+        spark.conf.set("spark.databricks.delta.uniform.readIcebergEnabled", "true")
+    except Exception:
+        logger.info(
+            "spark.databricks.delta.uniform.readIcebergEnabled is not available on this "
+            "Databricks Runtime. This is expected on runtimes where the feature has been "
+            "renamed to 'Read Iceberg Via Metadata Location' and is enabled at the "
+            "workspace level. Continuing without setting the config."
+        )
 
     reader = PolarisSQLReader()
     namespaces = reader.list_namespaces()


### PR DESCRIPTION
## Summary
- Databricks renamed **"Foreign Iceberg Tables Private Preview"** to **"Read Iceberg Via Metadata Location"** on newer runtimes
- The Spark config `spark.databricks.delta.uniform.readIcebergEnabled` no longer exists on these runtimes and throws `CONFIG_NOT_AVAILABLE` when set via `spark.conf.set()`
- Wrapped the config call in a **try/except** block in both `dbx_foreign_iceberg_tables_create.py` and `dbx_foreign_iceberg_tables_refresh.py`
- On older runtimes, the config is set as before; on newer runtimes, a clear info log is emitted and execution continues normally

## Context
Discovered via **ZD-123521** (Kaizen Gaming). Customer had the workspace-level feature enabled but the scripts failed with:
```
[CONFIG_NOT_AVAILABLE.WITHOUT_SUGGESTION] Configuration spark.databricks.delta.uniform.readIcebergEnabled is not available. SQLSTATE: 42K0I
```
Commenting out the line resolved the issue — tables created and refreshed successfully.

## Test plan
- [ ] Verify script runs on a Databricks workspace with the **old** "Foreign Iceberg Tables Private Preview" (config should be set successfully)
- [ ] Verify script runs on a Databricks workspace with the **new** "Read Iceberg Via Metadata Location" feature (config error should be caught gracefully, info log emitted, script continues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)