### PR TITLE
fix: log exceptions when no valid Polaris catalog is detected

### DIFF
--- a/databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_create.py
+++ b/databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_create.py
@@ -54,6 +54,7 @@ class PolarisSQLReader:
         """
         logger.info("Detecting Polaris catalog...")
 
+        errors = {}
         for candidate in ["atlan-wh", "context_store"]:
             try:
                 test_catalog = load_catalog(
@@ -67,9 +68,14 @@ class PolarisSQLReader:
                 if namespaces:
                     logger.info(f"Using catalog: {candidate}")
                     return candidate, candidate
-            except Exception:
+            except Exception as e:
+                errors[candidate] = e
                 logger.info(f"Catalog not accessible: {candidate}")
 
+        logger.error(
+            "No valid Polaris catalog found. Errors per candidate: "
+            + "; ".join(f"{name}: {err!r}" for name, err in errors.items())
+        )
         raise RuntimeError("No valid Polaris catalog found")
 
     def connect_to_catalog(self):

--- a/databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_refresh.py
+++ b/databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_refresh.py
@@ -54,6 +54,7 @@ class PolarisSQLReader:
         """
         logger.info("Detecting Polaris catalog...")
 
+        errors = {}
         for candidate in ["atlan-wh", "context_store"]:
             try:
                 test_catalog = load_catalog(
@@ -67,9 +68,14 @@ class PolarisSQLReader:
                 if namespaces:
                     logger.info(f"Using catalog: {candidate}")
                     return candidate, candidate
-            except Exception:
+            except Exception as e:
+                errors[candidate] = e
                 logger.info(f"Catalog not accessible: {candidate}")
 
+        logger.error(
+            "No valid Polaris catalog found. Errors per candidate: "
+            + "; ".join(f"{name}: {err!r}" for name, err in errors.items())
+        )
         raise RuntimeError("No valid Polaris catalog found")
 
     def connect_to_catalog(self):


### PR DESCRIPTION
## What

`detect_catalog` in the Databricks foreign-iceberg-tables scripts tries `atlan-wh` then `context_store`. Previously each candidate's exception was swallowed (`except Exception:` with only a generic info log), so when neither catalog was accessible the only signal was a bare `RuntimeError("No valid Polaris catalog found")` — with no clue as to *why* (auth, connectivity, missing warehouse, etc.).

## Change

- Capture each candidate's exception into an `errors` dict.
- When both candidates fail, log all captured exceptions once via `logger.error` before raising, so the underlying cause is visible.
- Existing per-candidate `logger.info("Catalog not accessible: ...")` behavior is preserved.

Applied to both:
- `databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_create.py`
- `databricks/foreign-iceberg-tables/dbx_foreign_iceberg_tables_refresh.py`